### PR TITLE
Adding quiet zone header to control the quiet zone

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -64,7 +64,7 @@ PARAMETERS:
                                     H
                                 Default: L
 
-    X-QR-Quiet-zone             Specify whether the quiet zone is added
+    X-QR-Quiet-Zone             Specify whether the quiet zone is added
                                 Options:
                                     true
                                     false

--- a/README.txt
+++ b/README.txt
@@ -64,6 +64,12 @@ PARAMETERS:
                                     H
                                 Default: L
 
+    X-QR-Quiet-zone             Specify whether the quiet zone is added
+                                Options:
+                                    true
+                                    false
+                                Default: true
+
 PARAMETER EXAMPLES:
 
     $ curl qrcode.show/INPUT -H "Accept: image/svg+xml"

--- a/cf-worker/src/lib.rs
+++ b/cf-worker/src/lib.rs
@@ -65,6 +65,11 @@ fn generator_from_headers(headers: &Headers) -> Result<Generator> {
         }?;
     }
 
+    if let Some(val) = get_first_header_value(headers, "x-qr-quiet-zone") {
+        gen.quiet_zone =
+            val.parse().map(Some).or_else(|_| Err("Bad Request"))?;
+    }
+
     Ok(gen)
 }
 

--- a/libs/src/gen.rs
+++ b/libs/src/gen.rs
@@ -83,6 +83,8 @@ pub struct Generator {
     pub version_number: Option<i16>,
 
     pub error_correction_level: Option<EcLevel>,
+
+    pub quiet_zone: Option<bool>,
 }
 
 impl Generator {
@@ -134,6 +136,7 @@ impl Generator {
                             .map(|s| s.as_str())
                             .unwrap_or("#fff"),
                     ))
+                    .quiet_zone(self.quiet_zone.unwrap_or(true))
                     .build()
                     .into_bytes();
                 bytes.push(b'\n');
@@ -147,6 +150,7 @@ impl Generator {
                         self.min_width.unwrap_or(240),
                         self.min_height.unwrap_or(240),
                     )
+                    .quiet_zone(self.quiet_zone.unwrap_or(true))
                     .build();
                 let bytes = image.as_bytes();
                 let mut result: Vec<u8> = Default::default();
@@ -164,6 +168,7 @@ impl Generator {
                         self.min_width.unwrap_or(240),
                         self.min_height.unwrap_or(240),
                     )
+                    .quiet_zone(self.quiet_zone.unwrap_or(true))
                     .build();
                 let bytes = image.as_bytes();
                 let mut result: Vec<u8> = Default::default();
@@ -178,6 +183,7 @@ impl Generator {
                 let mut bytes = code
                     .render::<char>()
                     .module_dimensions(2, 1)
+                    .quiet_zone(self.quiet_zone.unwrap_or(true))
                     .build()
                     .into_bytes();
                 bytes.push(b'\n');
@@ -193,6 +199,7 @@ impl Generator {
                     )
                     .dark_color(unicode::Dense1x2::Dark)
                     .light_color(unicode::Dense1x2::Light)
+                    .quiet_zone(self.quiet_zone.unwrap_or(true))
                     .build()
                     .into_bytes();
                 bytes.push(b'\n');


### PR DESCRIPTION
Hi @sayanarijit 

This adds a quiet zone header. The quiet zone is a padding that is added to the QR code to help avoid the scanner picking up it's surroundings.
Ressource: https://delivr.com/faq/1455/whats-with-the-white-border-around-the-qr-code

I have added the quiet zone function call to all formats. The default behaviour is false. My change will not interfere with the default behaviour that this library has. It will however give me the option to disable the quiet zone.

Warning: I do not usually develop in Rust.
Which means I probably hasn't done it the right way. You know the gist though. So maybe you can help ease out the kinks?